### PR TITLE
Load action type ids from lib9c

### DIFF
--- a/src/components/form/ActionsSelect.vue
+++ b/src/components/form/ActionsSelect.vue
@@ -35,7 +35,7 @@ export default {
     data() {
         return {
             onoff: false,
-            items: ["activate_account", "activate_account2", "add_activated_account", "add_activated_account2", "add_redeem_code", "battle_arena", "buy", "buy2", "buy3", "buy4", "buy5", "buy6", "buy7", "buy8", "buy9", "buy10", "buy11", "buy12", "buy_multiple", "cancel_monster_collect", "charge_action_point", "charge_action_point2", "charge_action_point3", "claim_monster_collection_reward", "claim_monster_collection_reward2", "claim_monster_collection_reward3", "claim_stake_reward", "combination_consumable", "combination_consumable2", "combination_consumable3", "combination_consumable4", "combination_consumable5", "combination_consumable6", "combination_consumable7", "combination_consumable8", "combination_equipment", "combination_equipment2", "combination_equipment3", "combination_equipment4", "combination_equipment5", "combination_equipment6", "combination_equipment7", "combination_equipment8", "combination_equipment9", "combination_equipment10", "combination_equipment11", "combination_equipment12", "create_avatar", "create_avatar2", "create_avatar3", "create_avatar4", "create_avatar5", "create_avatar6", "create_avatar7", "create_avatar8", "create_pending_activation", "create_pending_activations", "daily_reward", "daily_reward2", "daily_reward3", "daily_reward4", "daily_reward5", "daily_reward6", "grinding", "hack_and_slash", "hack_and_slash2", "hack_and_slash3", "hack_and_slash4", "hack_and_slash5", "hack_and_slash6", "hack_and_slash7", "hack_and_slash8", "hack_and_slash9", "hack_and_slash10", "hack_and_slash11", "hack_and_slash12", "hack_and_slash13", "hack_and_slash14", "hack_and_slash_random_buff", "hack_and_slash_sweep", "hack_and_slash_sweep2", "hack_and_slash_sweep3", "hack_and_slash_sweep4", "hack_and_slash_sweep5", "initialize_states", "item_enhancement", "item_enhancement2", "item_enhancement3", "item_enhancement4", "item_enhancement5", "item_enhancement6", "item_enhancement7", "item_enhancement8", "item_enhancement9", "item_enhancement10", "item_enhancement11", "join_arena", "migrate_monster_collection", "migration_activated_accounts_state", "migration_avatar_state", "migration_legacy_shop", "migration_legacy_shop2", "mimisbrunnr_battle", "mimisbrunnr_battle2", "mimisbrunnr_battle3", "mimisbrunnr_battle4", "mimisbrunnr_battle5", "mimisbrunnr_battle6", "mimisbrunnr_battle7", "mimisbrunnr_battle8", "mimisbrunnr_battle9", "monster_collect", "monster_collect2", "monster_collect3", "patch_table_sheet", "ranking_battle", "ranking_battle2", "ranking_battle3", "ranking_battle4", "ranking_battle5", "ranking_battle6", "ranking_battle7", "ranking_battle8", "ranking_battle9", "ranking_battle10", "ranking_battle11", "ranking_battle12", "rapid_combination", "rapid_combination2", "rapid_combination3", "rapid_combination4", "rapid_combination5", "rapid_combination6", "redeem_code", "redeem_code2", "redeem_code3", "renew_admin_state", "sell", "sell2", "sell3", "sell4", "sell5", "sell6", "sell7", "sell8", "sell9", "sell10", "sell_cancellation", "sell_cancellation2", "sell_cancellation3", "sell_cancellation4", "sell_cancellation5", "sell_cancellation6", "sell_cancellation7", "sell_cancellation8", "sell_cancellation9", "stake", "transfer_asset", "transfer_asset2", "unlock_equipment_recipe", "unlock_world", "update_sell", "update_sell2"],
+            items: [],
             search: '',
         }
     },
@@ -48,7 +48,13 @@ export default {
         },
     },
     async created() {
+        const apvResponse = await fetch(`https://release.nine-chronicles.com/apv.json`);
+        const apvJson = await apvResponse.json();
+        const version = apvJson.apv.split('/')[0];
+        const actionTypeIdsResponse = await fetch(`https://planetarium.github.io/lib9c/v${version}/all_action_type_ids.txt`);
+        const actionTypeIds = (await actionTypeIdsResponse.text()).split('\n');
 
+        this.items = actionTypeIds;
     },
     methods: {
         open() {


### PR DESCRIPTION
Originally, the action filter items were hard-coded.

But there is `https://release.nine-chronicles.com/apv.json`, a JSON file including information related to the mainnet network.
And there is `https://planetarium.github.io/lib9c/{VERSION}/all_action_type_ids.txt`, a text file including all action type ids in the `VERSION` separated by a newline.

This pull request makes the action filter load items from `https://planetarium.github.io/lib9c/{VERSION}/all_action_type_ids.txt`.