### PR TITLE
Use `main/config.json` instead of `apv.json`

### DIFF
--- a/src/components/form/ActionsSelect.vue
+++ b/src/components/form/ActionsSelect.vue
@@ -48,9 +48,9 @@ export default {
         },
     },
     async created() {
-        const apvResponse = await fetch(`https://release.nine-chronicles.com/apv.json`);
+        const apvResponse = await fetch(`https://release.nine-chronicles.com/main/config.json`);
         const apvJson = await apvResponse.json();
-        const version = apvJson.apv.split('/')[0];
+        const version = apvJson.AppProtocolVersion.split('/')[0];
         const actionTypeIdsResponse = await fetch(`https://planetarium.github.io/lib9c/v${version}/all_action_type_ids.txt`);
         const actionTypeIds = (await actionTypeIdsResponse.text()).split('\n');
 


### PR DESCRIPTION
Since Planetarium changed the release bucket's policy, `/apv.json` was deprecated, and `9c-launcher-config.json` moved to `/main/config.json`. It makes 9cscan use `/main/config.json`.

You can see the config.json file at https://release.nine-chronicles.com/main/config.json.